### PR TITLE
LA-1864 - Allow generation both `useMutation` & `useQuery` hooks for operations

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -397,6 +397,11 @@ export type HonoOptions = {
   handlers?: string;
 };
 
+export type CustomOptions = {
+  queryHookSuffix: string;
+  queryKeySuffix: string;
+};
+
 export type NormalizedQueryOptions = {
   useQuery?: boolean;
   useSuspenseQuery?: boolean;
@@ -406,6 +411,7 @@ export type NormalizedQueryOptions = {
   useInfiniteQueryParam?: string;
   usePrefetch?: boolean;
   options?: any;
+  customOptions?: CustomOptions;
   queryKey?: NormalizedMutator;
   queryOptions?: NormalizedMutator;
   mutationOptions?: NormalizedMutator;
@@ -423,6 +429,7 @@ export type QueryOptions = {
   useInfiniteQueryParam?: string;
   usePrefetch?: boolean;
   options?: any;
+  customOptions?: CustomOptions;
   queryKey?: Mutator;
   queryOptions?: Mutator;
   mutationOptions?: Mutator;

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -486,6 +486,9 @@ const normalizeQueryOptions = (
       ? { useInfiniteQueryParam: queryOptions.useInfiniteQueryParam }
       : {}),
     ...(queryOptions.options ? { options: queryOptions.options } : {}),
+    ...(queryOptions.customOptions
+      ? { customOptions: queryOptions.customOptions }
+      : {}),
     ...(queryOptions?.queryKey
       ? {
           queryKey: normalizeMutator(outputWorkspace, queryOptions?.queryKey),

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -64,6 +64,10 @@ export default defineConfig({
           useQuery: true,
           useInfinite: true,
           useInfiniteQueryParam: 'limit',
+          customOptions: {
+            queryHookSuffix: 'query',
+            queryKeySuffix: '-query',
+          },
         },
       },
     },


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE/standard_pr.md -->

## Summary

This PR adds support for `customOptions` to add suffixes to query hooks and query keys. This was added to avoid conflicts for operations with both `useMutation` and `useQuery`.  

> This ports all the changes from [@vetster/vetster-api-sdk-js/generator/patches/@orval+query+6.28.2.patch](https://github.com/vetster/vetster-api-sdk-js/blob/main/generator/patches/%40orval%2Bquery%2B6.28.2.patch)

## Changes

- Added support for `customOptions`
  - `queryHookSuffix` - Add a word at the end of the query hook name
  - `queryKeySuffix` - Add a word at the end of the query key
- Updated test case for `customOptions`

## Depedencies

- #2 

## Links

- [LA-1864](https://your-jira-instance/browse/LA-1864)

[LA-1864]: https://vetster.atlassian.net/browse/LA-1864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ