### PR TITLE
LA-1864 - Allow overriding operations to support both query & infinite query using the same custom `queryOptions` mutator

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1072,7 +1072,9 @@ ${hookOptions}
           ? `const customOptions = ${
               queryOptionsMutator.name
             }({...queryOptions, queryKey, queryFn}${
-              queryOptionsMutator.hasSecondArg ? `, { ${queryProperties} }` : ''
+              queryOptionsMutator.hasSecondArg
+                ? `, { infinite: ${type === QueryType.INFINITE}, ${queryProperties} }`
+                : ''
             }${
               queryOptionsMutator.hasThirdArg ? `, { url: \`${route}\` }` : ''
             });`


### PR DESCRIPTION
## Summary

This PR introduces support for passing the `infinite` property when a custom options mutator is specified in the query options. This was added to allow overriding operations to support both query & infinite query using the same custom `queryOptions` mutator with the additional infinite context for conditional behaviour). [This section](https://github.com/vetster/vetster-api-sdk-js/blob/81fda01b3fc9efd202c3cf17690438816e3bce1e/generator/base/infiniteQueryOptions.ts#L20-L38) uses this `infinite` property to add `getNextPageParam` and `getPreviousPageParam` for infinite queries.
## Changes

- Updated the logic to include the `infinite` property when `queryOptionsMutator` has a second argument.

## Dependencies

- #2 

## Links

- [LA-1864](https://your-jira-instance/browse/LA-1864)


[LA-1864]: https://vetster.atlassian.net/browse/LA-1864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ