### PR TITLE
LA-1864 - `GlobalMockOptions` includes prop for additional mock import dependencies

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -246,7 +246,7 @@ export type GlobalMockOptions = {
   // This is used to set the locale of the faker library
   locale?: keyof typeof allLocales;
   // This is used to add extra import dependencies to the generated mock file
-  extraImportDependencies?: GeneratorDependency[];
+  dependencies?: GeneratorDependency[];
 };
 
 export type OverrideMockOptions = Partial<GlobalMockOptions> & {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -245,6 +245,8 @@ export type GlobalMockOptions = {
   baseUrl?: string;
   // This is used to set the locale of the faker library
   locale?: keyof typeof allLocales;
+  // This is used to add extra import dependencies to the generated mock file
+  extraImportDependencies?: GeneratorDependency[];
 };
 
 export type OverrideMockOptions = Partial<GlobalMockOptions> & {

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -39,7 +39,11 @@ export const generateMSWImports: GenerateMockImports = ({
 }) => {
   return generateDependencyImports(
     implementation,
-    [...getMSWDependencies(options?.locale), ...imports],
+    [
+      ...getMSWDependencies(options?.locale),
+      ...(options?.extraImportDependencies || []),
+      ...imports,
+    ],
     specsName,
     hasSchemaDir,
     isAllowSyntheticDefaultImports,

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -41,7 +41,7 @@ export const generateMSWImports: GenerateMockImports = ({
     implementation,
     [
       ...getMSWDependencies(options?.locale),
-      ...(options?.extraImportDependencies || []),
+      ...(options?.dependencies || []),
       ...imports,
     ],
     specsName,


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE/standard_pr.md -->

## Summary

This PR adds support for extra dependencies in the generated mock file. This new feature allows specifying additional dependencies required for the mock setup.

## Changes

- Added support for `dependencies ` to provide additional imports during mocks

## Usage

Add the following lines to `generator/orval-config.js`
```js
{
  dependencies: [
    {
      exports: [
        {name: 'JSendSuccessResponse', values: true},
        {name: 'JSendFailResponse', values: true},
      ],
      dependency: '../../jsend/jsend',
    },
  ],
}
```

It will output the following in `*.msw.ts`

```js
import {JSendSuccessResponse} from '../../jsend/jsend';
```

[Example output](https://github.com/vetster/vetster-api-sdk-js/blob/81fda01b3fc9efd202c3cf17690438816e3bce1e/src/api/address/address.msw.ts#L10)


## Links

- [LA-1864](https://your-jira-instance/browse/LA-1864)



[LA-1864]: https://vetster.atlassian.net/browse/LA-1864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ