### PR TITLE
LA-1859 - Allow generation of prefetch functions separately for SSR

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -417,6 +417,7 @@ export type NormalizedQueryOptions = {
   queryKey?: NormalizedMutator;
   queryOptions?: NormalizedMutator;
   mutationOptions?: NormalizedMutator;
+  shouldExportHooks?: boolean;
   shouldExportMutatorHooks?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -418,8 +418,7 @@ export type NormalizedQueryOptions = {
   queryOptions?: NormalizedMutator;
   mutationOptions?: NormalizedMutator;
   shouldExportMutatorHooks?: boolean;
-  shouldGenerateHooks?: boolean;
-  skipImplementationWithoutHooks?: boolean;
+  shouldGeneratePrefetchOnly?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };
@@ -438,8 +437,7 @@ export type QueryOptions = {
   queryOptions?: Mutator;
   mutationOptions?: Mutator;
   shouldExportMutatorHooks?: boolean;
-  shouldGenerateHooks?: boolean;
-  skipImplementationWithoutHooks?: boolean;
+  shouldGeneratePrefetchOnly?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -417,8 +417,8 @@ export type NormalizedQueryOptions = {
   queryKey?: NormalizedMutator;
   queryOptions?: NormalizedMutator;
   mutationOptions?: NormalizedMutator;
-  shouldExportHooks?: boolean;
   shouldExportMutatorHooks?: boolean;
+  shouldExportHooks?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };
@@ -437,6 +437,7 @@ export type QueryOptions = {
   queryOptions?: Mutator;
   mutationOptions?: Mutator;
   shouldExportMutatorHooks?: boolean;
+  shouldExportHooks?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -418,7 +418,7 @@ export type NormalizedQueryOptions = {
   queryOptions?: NormalizedMutator;
   mutationOptions?: NormalizedMutator;
   shouldExportMutatorHooks?: boolean;
-  shouldExportHooks?: boolean;
+  shouldGenerateHooks?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };
@@ -437,7 +437,7 @@ export type QueryOptions = {
   queryOptions?: Mutator;
   mutationOptions?: Mutator;
   shouldExportMutatorHooks?: boolean;
-  shouldExportHooks?: boolean;
+  shouldGenerateHooks?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -419,6 +419,7 @@ export type NormalizedQueryOptions = {
   mutationOptions?: NormalizedMutator;
   shouldExportMutatorHooks?: boolean;
   shouldGenerateHooks?: boolean;
+  skipImplementationWithoutHooks?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };
@@ -438,6 +439,7 @@ export type QueryOptions = {
   mutationOptions?: Mutator;
   shouldExportMutatorHooks?: boolean;
   shouldGenerateHooks?: boolean;
+  skipImplementationWithoutHooks?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -513,14 +513,8 @@ const normalizeQueryOptions = (
     ...(!isUndefined(queryOptions.shouldExportMutatorHooks)
       ? { shouldExportMutatorHooks: queryOptions.shouldExportMutatorHooks }
       : {}),
-    ...(!isUndefined(queryOptions.shouldGenerateHooks)
-      ? { shouldGenerateHooks: queryOptions.shouldGenerateHooks }
-      : {}),
-    ...(!isUndefined(queryOptions.skipImplementationWithoutHooks)
-      ? {
-          skipImplementationWithoutHooks:
-            queryOptions.skipImplementationWithoutHooks,
-        }
+    ...(!isUndefined(queryOptions.shouldGeneratePrefetchOnly)
+      ? { shouldGeneratePrefetchOnly: queryOptions.shouldGeneratePrefetchOnly }
       : {}),
     ...(!isUndefined(queryOptions.signal)
       ? { signal: queryOptions.signal }

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -516,6 +516,12 @@ const normalizeQueryOptions = (
     ...(!isUndefined(queryOptions.shouldGenerateHooks)
       ? { shouldGenerateHooks: queryOptions.shouldGenerateHooks }
       : {}),
+    ...(!isUndefined(queryOptions.skipImplementationWithoutHooks)
+      ? {
+          skipImplementationWithoutHooks:
+            queryOptions.skipImplementationWithoutHooks,
+        }
+      : {}),
     ...(!isUndefined(queryOptions.signal)
       ? { signal: queryOptions.signal }
       : {}),

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -513,8 +513,8 @@ const normalizeQueryOptions = (
     ...(!isUndefined(queryOptions.shouldExportMutatorHooks)
       ? { shouldExportMutatorHooks: queryOptions.shouldExportMutatorHooks }
       : {}),
-    ...(!isUndefined(queryOptions.shouldExportHooks)
-      ? { shouldExportHooks: queryOptions.shouldExportHooks }
+    ...(!isUndefined(queryOptions.shouldGenerateHooks)
+      ? { shouldGenerateHooks: queryOptions.shouldGenerateHooks }
       : {}),
     ...(!isUndefined(queryOptions.signal)
       ? { signal: queryOptions.signal }

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -513,6 +513,9 @@ const normalizeQueryOptions = (
     ...(!isUndefined(queryOptions.shouldExportMutatorHooks)
       ? { shouldExportMutatorHooks: queryOptions.shouldExportMutatorHooks }
       : {}),
+    ...(!isUndefined(queryOptions.shouldExportHooks)
+      ? { shouldExportHooks: queryOptions.shouldExportHooks }
+      : {}),
     ...(!isUndefined(queryOptions.signal)
       ? { signal: queryOptions.signal }
       : {}),

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -523,7 +523,6 @@ const QueryType = {
   QUERY: 'query' as QueryType,
   SUSPENSE_QUERY: 'suspenseQuery' as QueryType,
   SUSPENSE_INFINITE: 'suspenseInfiniteQuery' as QueryType,
-  PREFETCH: 'prefetch' as QueryType,
 };
 
 const INFINITE_QUERY_PROPERTIES = ['getNextPageParam', 'getPreviousPageParam'];
@@ -1104,6 +1103,11 @@ ${hookOptions}
   const operationPrefix = hasSvelteQueryV4 ? 'create' : 'use';
 
   const hook = `
+export type ${pascal(
+    name,
+  )}QueryResult = NonNullable<Awaited<ReturnType<${dataType}>>>
+export type ${pascal(name)}QueryError = ${errorType}
+
   ${doc}export const ${camel(
     `${operationPrefix}-${name}${customOptions?.queryHookSuffix ? `-${customOptions.queryHookSuffix}` : ''}`,
   )} = <TData = ${TData}, TError = ${errorType}>(\n ${queryProps} ${queryArguments}\n  ): ${returnType} => {
@@ -1126,11 +1130,6 @@ ${hookOptions}
 
   return `
 ${queryOptionsFn}
-
-export type ${pascal(
-    name,
-  )}QueryResult = NonNullable<Awaited<ReturnType<${dataType}>>>
-export type ${pascal(name)}QueryError = ${errorType}
 
 ${shouldExportHooks ? hook : ''}
 
@@ -1290,16 +1289,6 @@ const generateQueryHook = async (
               options: query?.options,
               customOptions: query?.customOptions,
               type: QueryType.QUERY,
-            },
-          ]
-        : []),
-      ...(query?.usePrefetch || operationQueryOptions?.usePrefetch
-        ? [
-            {
-              name: operationName,
-              options: query?.options,
-              customOptions: query?.customOptions,
-              type: QueryType.PREFETCH,
               shouldExportHooks: query?.shouldExportHooks,
             },
           ]

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -861,7 +861,7 @@ const generateQueryImplementation = ({
     options,
     type,
     customOptions,
-    shouldGenerateHooks = true,
+    shouldGeneratePrefetchOnly,
   },
   operationName,
   queryKeyFnName,
@@ -891,7 +891,7 @@ const generateQueryImplementation = ({
     type: QueryType;
     queryParam?: string;
     customOptions?: CustomOptions;
-    shouldGenerateHooks?: boolean;
+    shouldGeneratePrefetchOnly?: boolean;
   };
   isRequestOptions: boolean;
   operationName: string;
@@ -1131,7 +1131,7 @@ export type ${pascal(name)}QueryError = ${errorType}
   return `
 ${queryOptionsFn}
 
-${shouldGenerateHooks ? hook : ''}
+${!shouldGeneratePrefetchOnly ? hook : ''}
 
 ${
   usePrefetch && (type === QueryType.QUERY || type === QueryType.INFINITE)
@@ -1289,7 +1289,7 @@ const generateQueryHook = async (
               options: query?.options,
               customOptions: query?.customOptions,
               type: QueryType.QUERY,
-              shouldGenerateHooks: query?.shouldGenerateHooks,
+              shouldGeneratePrefetchOnly: query?.shouldGeneratePrefetchOnly,
             },
           ]
         : []),
@@ -1589,7 +1589,7 @@ export const generateQuery: ClientBuilder = async (
   const implementation = `${functionImplementation}\n\n${hookImplementation}`;
 
   return {
-    implementation: options?.override?.query?.skipImplementationWithoutHooks
+    implementation: options?.override?.query?.shouldGeneratePrefetchOnly
       ? hookImplementation
         ? implementation
         : ''

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1586,8 +1586,14 @@ export const generateQuery: ClientBuilder = async (
   const { implementation: hookImplementation, mutators } =
     await generateQueryHook(verbOptions, options, outputClient);
 
+  const implementation = `${functionImplementation}\n\n${hookImplementation}`;
+
   return {
-    implementation: `${functionImplementation}\n\n${hookImplementation}`,
+    implementation: options?.override?.query?.skipImplementationWithoutHooks
+      ? hookImplementation
+        ? implementation
+        : ''
+      : implementation,
     imports,
     mutators,
   };

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -861,7 +861,7 @@ const generateQueryImplementation = ({
     options,
     type,
     customOptions,
-    shouldExportHooks = true,
+    shouldGenerateHooks = true,
   },
   operationName,
   queryKeyFnName,
@@ -891,7 +891,7 @@ const generateQueryImplementation = ({
     type: QueryType;
     queryParam?: string;
     customOptions?: CustomOptions;
-    shouldExportHooks?: boolean;
+    shouldGenerateHooks?: boolean;
   };
   isRequestOptions: boolean;
   operationName: string;
@@ -1131,7 +1131,7 @@ export type ${pascal(name)}QueryError = ${errorType}
   return `
 ${queryOptionsFn}
 
-${shouldExportHooks ? hook : ''}
+${shouldGenerateHooks ? hook : ''}
 
 ${
   usePrefetch && (type === QueryType.QUERY || type === QueryType.INFINITE)
@@ -1289,7 +1289,7 @@ const generateQueryHook = async (
               options: query?.options,
               customOptions: query?.customOptions,
               type: QueryType.QUERY,
-              shouldExportHooks: query?.shouldExportHooks,
+              shouldGenerateHooks: query?.shouldGenerateHooks,
             },
           ]
         : []),

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -50,7 +50,7 @@ export const normalizeQueryOptions = (
     ...(queryOptions.shouldExportMutatorHooks
       ? { shouldExportMutatorHooks: true }
       : {}),
-    ...(queryOptions.shouldExportHooks ? { shouldExportHooks: true } : {}),
+    ...(queryOptions.shouldGenerateHooks ? { shouldGenerateHooks: true } : {}),
     ...(queryOptions.signal ? { signal: true } : {}),
   };
 };

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -51,6 +51,9 @@ export const normalizeQueryOptions = (
       ? { shouldExportMutatorHooks: true }
       : {}),
     ...(queryOptions.shouldGenerateHooks ? { shouldGenerateHooks: true } : {}),
+    ...(queryOptions.skipImplementationWithoutHooks
+      ? { skipImplementationWithoutHooks: true }
+      : {}),
     ...(queryOptions.signal ? { signal: true } : {}),
   };
 };

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -50,6 +50,7 @@ export const normalizeQueryOptions = (
     ...(queryOptions.shouldExportMutatorHooks
       ? { shouldExportMutatorHooks: true }
       : {}),
+    ...(queryOptions.shouldExportHooks ? { shouldExportHooks: true } : {}),
     ...(queryOptions.signal ? { signal: true } : {}),
   };
 };

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -50,9 +50,8 @@ export const normalizeQueryOptions = (
     ...(queryOptions.shouldExportMutatorHooks
       ? { shouldExportMutatorHooks: true }
       : {}),
-    ...(queryOptions.shouldGenerateHooks ? { shouldGenerateHooks: true } : {}),
-    ...(queryOptions.skipImplementationWithoutHooks
-      ? { skipImplementationWithoutHooks: true }
+    ...(queryOptions.shouldGeneratePrefetchOnly
+      ? { shouldGeneratePrefetchOnly: true }
       : {}),
     ...(queryOptions.signal ? { signal: true } : {}),
   };

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -24,8 +24,7 @@ export default defineConfig({
         query: {
           usePrefetch: true,
           useMutation: false,
-          shouldGenerateHooks: false,
-          skipImplementationWithoutHooks: true,
+          shouldGeneratePrefetchOnly: true,
         },
       },
     },

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -13,6 +13,26 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  basicPrefetch: {
+    output: {
+      target: '../generated/react-query/basic-prefetch/endpoints.ts',
+      schemas: '../generated/react-query/basic-prefetch/model',
+      client: 'react-query',
+      mock: true,
+      headers: true,
+      override: {
+        query: {
+          usePrefetch: true,
+          useMutation: false,
+          shouldGenerateHooks: false,
+          skipImplementationWithoutHooks: true,
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   petstoreTagsSplit: {
     output: {
       target: '../generated/react-query/petstore-tags-split/endpoints.ts',


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE/standard_pr.md -->

## Summary

This PR adds support for skipping hook generation and mutator function implementation during prefetch-only generation. This was needed to keep the prefetch queries separate from the normal hooks file for next.js as prefetch would be used on server side and hooks would be used on the client side

## Changes

- Added `shouldGeneratePrefetchOnly ` to toggle generation of `useQuery` and mutation queries axios implementation while generating prefetch functions

## Usage

Add the following lines to `generator/orval-config.js`
```js
{
  query: {
    override: {
        query: {
          usePrefetch: true,
          useMutation: false,
          shouldGeneratePrefetchOnly: true,
        },
      },
  }
}
```

It will output the following in `*.ts`

```tsx
export const prefetchLoremIpsum = async <
  TData = Awaited<ReturnType<typeof axiosFn>>,
  TError = AxiosError<Error>,
>(
  queryClient: QueryClient,
  params: LoremParams,
  headers: IpsumHeaders,
  options?: {
    query?: UseQueryOptions<
      Awaited<ReturnType<typeof axiosFn>>,
      TError,
      TData
    >;
    axios?: AxiosRequestConfig;
  },
): Promise<QueryClient> => {
  const queryOptions = getLoremIpsumQueryOptions(params, headers, options);

  await queryClient.prefetchQuery(queryOptions);

  return queryClient;
};
```

## Links

- [LA-1859](https://your-jira-instance/browse/LA-1859)


[LA-1859]: https://vetster.atlassian.net/browse/LA-1859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ