### PR TITLE
LA-1865 - Add support to add `use client` to the generated code

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -74,6 +74,7 @@ export type NormalizedOverrideOutput = {
   tags: { [key: string]: NormalizedOperationOptions };
   mock?: OverrideMockOptions;
   contentType?: OverrideOutputContentType;
+  addUseClientDirective?: boolean;
   header: false | ((info: InfoObject) => string[] | string);
   formData: boolean | NormalizedMutator;
   formUrlEncoded: boolean | NormalizedMutator;
@@ -313,6 +314,7 @@ export type OverrideOutput = {
   tags?: { [key: string]: OperationOptions };
   mock?: OverrideMockOptions;
   contentType?: OverrideOutputContentType;
+  addUseClientDirective?: boolean;
   header?: boolean | ((info: InfoObject) => string[] | string);
   formData?: boolean | Mutator;
   formUrlEncoded?: boolean | Mutator;

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -188,6 +188,7 @@ export const normalizeOptions = async (
             : isFunction(outputOptions.override?.header)
               ? outputOptions.override?.header!
               : getDefaultFilesHeader,
+        addUseClientDirective: !!outputOptions.override?.addUseClientDirective,
         requestOptions: outputOptions.override?.requestOptions ?? true,
         components: {
           schemas: {

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -57,9 +57,7 @@ export const writeSpecs = async (
     {} as Record<keyof typeof schemas, string>,
   );
 
-  const header =
-    (output.override.addUseClientDirective ? "'use client'" + '\n\n' : '') +
-    getHeader(output.override.header, info as InfoObject);
+  const header = getHeader(output.override.header, info as InfoObject);
 
   if (output.schemas) {
     const rootSchemaPath = output.schemas;
@@ -93,7 +91,9 @@ export const writeSpecs = async (
       workspace,
       output,
       specsName,
-      header,
+      header:
+        (output.override.addUseClientDirective ? "'use client'" + '\n\n' : '') +
+        header,
       needSchema: !output.schemas && output.client !== 'zod',
     });
   }

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -57,7 +57,9 @@ export const writeSpecs = async (
     {} as Record<keyof typeof schemas, string>,
   );
 
-  const header = getHeader(output.override.header, info as InfoObject);
+  const header =
+    (output.override.addUseClientDirective ? "'use client'" + '\n\n' : '') +
+    getHeader(output.override.header, info as InfoObject);
 
   if (output.schemas) {
     const rootSchemaPath = output.schemas;

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
       client: 'react-query',
       mock: true,
       headers: true,
+      override: {
+        addUseClientDirective: true,
+      },
     },
     input: {
       target: '../specifications/petstore.yaml',


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE/standard_pr.md -->

## Summary

This PR adds support to add `use client` on top of the generated file to not process files on server side

## Changes

- Added `addUseClientDirective` to add `'use client'` on top of the file


## Usage

Add the following lines to `generator/orval-config.js`
```js
{
  query: {
    override: {
        addUseClientDirective: true
      },
  }
}
```

It will output the following at the top of all the files

```tsx
'use client'
```